### PR TITLE
js-good-parts-0.0.2 doesn't build (at least not with current cabal and GHC)

### DIFF
--- a/js-good-parts.cabal
+++ b/js-good-parts.cabal
@@ -28,3 +28,4 @@ Library
   Exposed-Modules:    Language.JavaScript.AST
                       Language.JavaScript.Pretty
   Other-Modules:      Language.JavaScript.NonEmptyList
+                      Text.PrettyPrint.Leijen.PrettyPrec

--- a/src/Text/PrettyPrint/Leijen/PrettyPrec.hs
+++ b/src/Text/PrettyPrint/Leijen/PrettyPrec.hs
@@ -42,7 +42,8 @@ instance PrettyPrec Float
 instance PrettyPrec Double
 
 -- Orphan. Missing from wl-pprint
-instance Integral a => Pretty (Ratio a) where pretty = text . show
+instance (Integral a, Show a) => Pretty (Ratio a) where
+  pretty = text . show
 
 instance Pretty a => PrettyPrec [a]
 
@@ -53,7 +54,7 @@ instance (Pretty a,Pretty b,Pretty c) => PrettyPrec (a,b,c)
 instance PrettyPrec a => PrettyPrec (Maybe a) where
   prettyPrec p = maybe empty (prettyPrec p)
 
-instance Integral a => PrettyPrec (Ratio a) where
+instance (Integral a, Show a) => PrettyPrec (Ratio a) where
   prettyPrec = const (text . show)
 
 {--------------------------------------------------------------------


### PR DESCRIPTION
This commit fixes a couple things so the package builds with Cabal 1.14 and GHC 7.0.3, 7.2.2, and 7.4.1.
