### PR TITLE
Fixed bool pretty printing

### DIFF
--- a/src/Language/JavaScript/Pretty.hs
+++ b/src/Language/JavaScript/Pretty.hs
@@ -272,7 +272,7 @@ instance PrettyPrec Refinement -- default
 instance Pretty Lit             where
   pretty lit = case lit of
     LitNumber n   -> pretty n
-    LitBool   b   -> pretty b
+    LitBool   b   -> if b then text "true" else text "false"
     LitString s   -> pretty s
     LitObject o   -> pretty o
     LitArray  a   -> pretty a


### PR DESCRIPTION
Currently booleans are pretty printed like the would be in Haskell: upper case. This pull request just ensures that pretty printed bools are lower case.